### PR TITLE
Add GitHub Action to build CV PDF

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build CV PDF
+
+on:
+  push:
+    paths:
+      - '**.tex'
+      - '**.md'
+      - Makefile
+  pull_request:
+    paths:
+      - '**.tex'
+      - '**.md'
+      - Makefile
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile LaTeX
+        uses: xu-cheng/latex-action@v4
+        with:
+          root_file: cv.tex
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cv
+          path: cv.pdf


### PR DESCRIPTION
## Summary
- add workflow to compile cv.tex into a PDF on push and pull requests
- upload generated cv.pdf as a workflow artifact for download

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b43f26fc38832b8b384811283af9ea